### PR TITLE
Wrapped INP_GPIO macro in OUT_GPIO and SET_GPIO_ALT

### DIFF
--- a/PJ_RPI.h
+++ b/PJ_RPI.h
@@ -37,8 +37,14 @@ extern struct bcm2835_peripheral bsc0;	// so use extern!!
 
 // GPIO setup macros. Always use INP_GPIO(x) before using OUT_GPIO(x) or SET_GPIO_ALT(x,y)
 #define INP_GPIO(g) 	*(gpio.addr + ((g)/10)) &= ~(7<<(((g)%10)*3))
-#define OUT_GPIO(g) 	*(gpio.addr + ((g)/10)) |=  (1<<(((g)%10)*3))
-#define SET_GPIO_ALT(g,a) *(gpio.addr + (((g)/10))) |= (((a)<=3?(a) + 4:(a)==4?3:2)<<(((g)%10)*3))
+#define OUT_GPIO(g)   do { \
+  INP_GPIO(g); \
+  *(gpio.addr + ((g)/10)) |=  (1<<(((g)%10)*3)); \
+} while(0)
+#define SET_GPIO_ALT(g,a) do { \
+  INP_GPIO(g); \
+  *(gpio.addr + (((g)/10))) |= (((a)<=3?(a) + 4:(a)==4?3:2)<<(((g)%10)*3)); \
+} while(0)
 
 #define GPIO_SET 	*(gpio.addr + 7)  // sets   bits which are 1 ignores bits which are 0
 #define GPIO_CLR 	*(gpio.addr + 10) // clears bits which are 1 ignores bits which are 0


### PR DESCRIPTION
PUT INP_GPIO macro inside OUT_GPIO and SET_GPIO_ALT ones so only one macro must be written at a time.