### PR TITLE
Adding RPi2 support

### DIFF
--- a/Examples/MPU6050/Source/MPU6050.h
+++ b/Examples/MPU6050/Source/MPU6050.h
@@ -3,7 +3,8 @@
 
 #include "PJ_RPI.h"
 
-#define MPU6050_ADDR 0b01101001	// 7 bit adres 
+#define MPU6050_ADDR 0x68	// 7 bit adres 
+//#define MPU6050_ADDR 0x69     //One of these address should work. Depends on module HW address
 #define CONFIG 0x1A
 #define ACCEL_CONFIG 0x1C
 #define GYRO_CONFIG 0x1B

--- a/PJ_RPI.h
+++ b/PJ_RPI.h
@@ -17,9 +17,21 @@
 
 #include <unistd.h>
 
+// Define which Raspberry Pi board are you using. Take care to have defined only one at time.
+#define RPI
+//#define RPI2
+
+#ifdef RPI
 #define BCM2708_PERI_BASE       0x20000000
 #define GPIO_BASE               (BCM2708_PERI_BASE + 0x200000)	// GPIO controller 
-#define BSC0_BASE 		(BCM2708_PERI_BASE + 0x205000)	// I2C controller		
+#define BSC0_BASE 		(BCM2708_PERI_BASE + 0x205000)	// I2C controller	
+#endif
+
+#ifdef RPI2
+#define BCM2708_PERI_BASE       0x3F000000
+#define GPIO_BASE               (BCM2708_PERI_BASE + 0x200000)	// GPIO controller. Maybe wrong. Need to be tested.
+#define BSC0_BASE 		(BCM2708_PERI_BASE + 0x804000)	// I2C controller	
+#endif	
 
 #define PAGE_SIZE 		(4*1024)
 #define BLOCK_SIZE 		(4*1024)


### PR DESCRIPTION
Hi.
I added RPi2 support to your library. I have only MPU6050 availaible at this moment, so I2C and this module are only one tested. 
I made two defines for switching between RPi and RPi2.
Have a nice day.
Vojtech