### PR TITLE
Attempt to use /dev/gpiomem if available.

### DIFF
--- a/PJ_RPI.c
+++ b/PJ_RPI.c
@@ -6,10 +6,12 @@ struct bcm2835_peripheral bsc0 = {BSC0_BASE};
 // Exposes the physical address defined in the passed structure using mmap on /dev/mem
 int map_peripheral(struct bcm2835_peripheral *p)
 {
-   // Open /dev/mem
-   if ((p->mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
-      printf("Failed to open /dev/mem, try checking permissions.\n");
-      return -1;
+   // Attempt to open /dev/gpiomem or /dev/mem
+   if ((p->mem_fd = open("/dev/gpiomem", O_RDWR|O_SYNC) ) < 0) {
+      if ((p->mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
+        printf("Failed to open /dev/gpiomem or /dev/mem. If your system has a /dev/gpiomem device, make sure you have the gpio group permission, if not, you'll need to run as root.\n");
+        return -1;
+      }
    }
 
    p->map = mmap(

--- a/PJ_RPI.h
+++ b/PJ_RPI.h
@@ -18,8 +18,8 @@
 #include <unistd.h>
 
 // Define which Raspberry Pi board are you using. Take care to have defined only one at time.
-#define RPI
-//#define RPI2
+//#define RPI
+#define RPI2
 
 #ifdef RPI
 #define BCM2708_PERI_BASE       0x20000000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 To install:
-    - mkdir Build
-    - cd Build
-    - cmake ../
-    - make
-    - sudo make install
+* edit PJ_RPI.h to set the version of board (+uncomment NO_GPIOMEM if you want to)
+* mkdir Build
+* cd Build
+* cmake ../
+* make
+* sudo make install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 To install:
-* edit PJ_RPI.h to set the version of board (+uncomment NO_GPIOMEM if you want to)
+* edit PJ_RPI.h to set the version of board
 * mkdir Build
 * cd Build
 * cmake ../


### PR DESCRIPTION
This is a patch to add support for the new gpiomem device driver.  This means that programs you build with the library now support /dev/gpiomem by default if it is available, so they are are more secure and only need to run as a user with the gpio group, like any program that uses sysfs.  Also fixed a small bug in the markdown format on the Readme file so it looks clearer in the github website.

The implementation attempts to open /dev/gpiomem first then if it fails, silently falls back to /dev/mem.
